### PR TITLE
Add canonical sources section to SKILL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Joomla skill are documented here. The format follows 
 ## [Unreleased]
 
 ### Added
+- `## Canonical sources` section in `SKILL.md` listing the upstream references the skill is built from (joomla-cms repo, manual.joomla.org, api.joomla.org, framework.joomla.org, docs.joomla.org wiki) with WebFetch-first / fallback guidance and a preference for commit-pinned permalinks. Mirrored in `CONTRIBUTING.md` and `README.md`.
 - `CONTRIBUTING.md` covering testing flow, authoring guidelines, PR process, issue guidelines, and versioning.
 - `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, summarized + linked).
 - Issue forms: `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml`, plus `config.yml` redirecting Joomla-CMS questions to upstream.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ If you change `name` or `description`:
 ### Body and references
 
 - **Be concrete.** Show the actual file structure, the actual XML tag, the actual class name. Vague advice ("set up a service provider") is worse than no advice; Claude will pattern-match on it and produce nonsense.
-- **Cite [`joomla/joomla-cms`](https://github.com/joomla/joomla-cms) when behavior is non-obvious.** A link to the commit or file that proves the pattern saves future maintenance.
+- **Cite [`joomla/joomla-cms`](https://github.com/joomla/joomla-cms) when behavior is non-obvious.** A link to the commit or file that proves the pattern saves future maintenance. The skill's `## Canonical sources` section lists the upstream references the skill is built from — verify changes against them, and prefer **commit-pinned permalinks** to `joomla-cms` over branch links so the citation does not silently drift.
 - **Target Joomla 6, backward compatible to 5** unless the section explicitly says otherwise. Note the version a feature appeared in if it matters.
 - **PHP 8.2+ syntax** in examples (constructor promotion, readonly, enums, named args where they help).
 - **PSR-12 PHP, Joomla ESLint config for JS.** Don't introduce styles that contradict either.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This skill is maintained by [Christian Web Ministries](https://christianwebminis
 - [CWMScriptureLinks](https://github.com/bcordis/CWMScriptureLinks) — auto-link Scripture references
 - Other CWM extensions
 
-Patterns are derived from the [joomla-cms](https://github.com/joomla/joomla-cms) core and real-world production components.
+Patterns are derived from the [joomla-cms](https://github.com/joomla/joomla-cms) core and real-world production components. The skill's `## Canonical sources` section in [`skills/joomla/SKILL.md`](skills/joomla/SKILL.md) lists every upstream reference (joomla-cms, manual.joomla.org, api.joomla.org, framework.joomla.org) Claude consults when verifying patterns — and the fallback order when WebFetch is unavailable.
 
 ## Contributing
 

--- a/skills/joomla/SKILL.md
+++ b/skills/joomla/SKILL.md
@@ -12,6 +12,31 @@ This skill guides you through building Joomla 5+ extensions (components, modules
 **PHP requirement:** 8.2+ (Joomla 6 minimum), 8.3+ recommended
 **Coding standard:** PSR-12 (PHP), Joomla ESLint config (JavaScript)
 
+## Canonical sources
+
+When a Joomla pattern is non-obvious, ambiguous, or might have drifted between versions, verify against upstream before answering. Prefer fetching directly with WebFetch; if the fetch is blocked, fails, or the user is offline, fall back in this order: (1) cite the canonical URL so the user can open it, (2) rely on the patterns documented in this skill and `references/*.md`, (3) ask the user to paste the relevant snippet rather than guess.
+
+**Primary — source of truth for runtime behavior:**
+
+- [`github.com/joomla/joomla-cms`](https://github.com/joomla/joomla-cms) — core CMS. Use branch `5.3-dev` for current Joomla 5, `6.0-dev` for Joomla 6 work.
+  - Frontend component examples: [`components/`](https://github.com/joomla/joomla-cms/tree/6.0-dev/components)
+  - Backend component examples: [`administrator/components/`](https://github.com/joomla/joomla-cms/tree/6.0-dev/administrator/components)
+  - Core plugins: [`plugins/`](https://github.com/joomla/joomla-cms/tree/6.0-dev/plugins)
+  - Core modules: [`modules/`](https://github.com/joomla/joomla-cms/tree/6.0-dev/modules) and [`administrator/modules/`](https://github.com/joomla/joomla-cms/tree/6.0-dev/administrator/modules)
+  - Framework libraries shipped with the CMS: [`libraries/src/`](https://github.com/joomla/joomla-cms/tree/6.0-dev/libraries/src)
+- [`github.com/joomla-framework`](https://github.com/joomla-framework) — standalone Framework packages (DI, Event, Filesystem, etc.) reused by the CMS.
+
+**Documentation:**
+
+- [manual.joomla.org](https://manual.joomla.org/) — current Developer Manual (Joomla 5+). Preferred prose reference.
+- [api.joomla.org](https://api.joomla.org/) — generated API reference (classes, methods, signatures).
+- [framework.joomla.org](https://framework.joomla.org/) — Joomla Framework package docs.
+- [docs.joomla.org](https://docs.joomla.org/) — **legacy wiki**. Useful for historical context (J3/J4) but often stale for J5/J6; cross-check against `joomla-cms` HEAD before quoting.
+
+**When citing in generated code or replies:** prefer a permalink to a specific file/line in `joomla-cms` (right-click → "Copy permalink" produces a commit-pinned URL) over a branch link, so the reference does not silently drift.
+
+**Update cadence:** if a WebFetch reveals the upstream pattern differs from what this skill teaches, flag it to the user and recommend opening an issue on `Joomla-Bible-Study/claude-skill-joomla` so the skill can be corrected.
+
 ## Coding Standards
 
 ### PHPDoc / DocBlocks


### PR DESCRIPTION
Documents the upstream references Claude consults when verifying
Joomla patterns: joomla-cms repo (5.3-dev / 6.0-dev branches),
manual.joomla.org, api.joomla.org, framework.joomla.org, plus the
legacy docs.joomla.org wiki. Specifies WebFetch as preferred with a
fallback order (cite URL → use skill content → ask user) for when
network access is blocked, and prefers commit-pinned permalinks over
branch links to avoid silent drift. Mirrored briefly in
CONTRIBUTING.md and README.md so contributors verify against the same
sources.

https://claude.ai/code/session_01ECqRr7XfdarEZoPgCiSqpu