### PR TITLE
Remove brand-specific references (CWM / Proclaim / EventBooking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to the Joomla skill are documented here. The format follows 
 - All four in-file PHP-version code examples bumped from 8.2 → 8.3 to match the J6.x floor (changelog `<note>`, update-server `<php_minimum>`, install-script `$minimumPhp`, `composer.json` `php` constraint). The `$minimumJoomla` example value is unchanged because it declares which Joomla versions the extension supports — independent of PHP — and a J6-native extension that also supports J5.x must still pin PHP to 8.3.0 (the highest supported-Joomla floor).
 - `SKILL.md` shrunk from 3594 to ~1180 fewer lines by replacing the in-file Editor API, Form Fields, Testing, and Common Gotchas sections with short pointer stubs that name the topics covered. Reduces the per-load token cost without losing any content (full text preserved in the new `references/*.md` files).
 
+### Fixed
+- Removed brand-specific references (CWM / Proclaim / EventBooking) from `SKILL.md` and `references/module.md`. The skill is generic Joomla guidance and shouldn't lean on specific third-party extension code or naming conventions as canonical examples. Replaced with vendor-neutral placeholders (`<Vendor>`, `Acme`, generic `bookings`/`items`) and a generic note about projects shipping admin + site modules in one source tree. The `Joomla-Bible-Study/claude-skill-joomla` GitHub URL stays — that's the skill's own home, not borrowed code.
+
 ## [0.1.0] — 2026-04-29
 
 ### Added

--- a/skills/joomla/SKILL.md
+++ b/skills/joomla/SKILL.md
@@ -504,9 +504,9 @@ Joomla has strict naming that connects everything automatically:
 | Edit template | `tmpl/{entity}/edit.php` | `tmpl/booking/edit.php` |
 | List template | `tmpl/{entity}s/default.php` | `tmpl/bookings/default.php` |
 
-Some projects use a prefix on entity names (e.g., `CwmBooking` for CWM components). This is optional but helps avoid naming collisions with other extensions.
+Some projects use a vendor prefix on entity names (e.g., `AcmeBooking` instead of plain `Booking`). This is optional but helps avoid naming collisions with other extensions.
 
-The view name in the URL (`&view=cwmmessages`) must match the View directory name (case-insensitive on the URL side, but the directory must match the class namespace).
+The view name in the URL (e.g., `&view=bookings`) must match the View directory name (case-insensitive on the URL side, but the directory must match the class namespace).
 
 ### 7. Database Patterns
 
@@ -2387,7 +2387,7 @@ When working on a Joomla project, check whether the project has its own `CLAUDE.
 
 Common patterns seen in production Joomla 5+ components:
 
-- **Entity prefixes** — Some projects prefix entity names to avoid collisions (e.g., `Cwm` prefix in CWM components, `Eb` in EventBooking). Follow the project's existing convention.
+- **Entity prefixes** — Some projects prefix entity names to avoid collisions (e.g., a `<Vendor>` prefix on every Model/View/Table class). Follow the project's existing convention.
 - **Plugin groups** — Real components typically ship with several plugin types: content, finder (Smart Search), schemaorg (structured data), system, task (scheduled jobs), and webservices (REST API).
 - **Module variants** — Both admin-side and site-side modules in `modules/admin/` and `modules/site/`.
 - **Build tooling** — Composer for PHP dependencies + npm for JS/CSS asset compilation. Look for `composer.json` and `package.json` at the project root.

--- a/skills/joomla/references/module.md
+++ b/skills/joomla/references/module.md
@@ -275,4 +275,4 @@ For admin-side modules, the structure is identical but:
   And the Dispatcher lives under the `Administrator` sub-namespace.
 - Placed in `administrator/modules/` when installed
 
-**Proclaim example**: The Proclaim project has modules under both `modules/admin/` and `modules/site/` in its development repo.
+In practice, larger Joomla projects often ship modules under both `modules/admin/` and `modules/site/` in the same source tree, so the build can package admin and site variants from one repo.


### PR DESCRIPTION
The skill is generic Joomla 5+/6 guidance; it shouldn't lean on specific third-party extension code or naming conventions as canonical examples.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `skills/joomla/SKILL.md` | 507 | `CwmBooking` for CWM components | `AcmeBooking` instead of plain `Booking` |
| `skills/joomla/SKILL.md` | 509 | `&view=cwmmessages` | `&view=bookings` (matches surrounding Booking examples) |
| `skills/joomla/SKILL.md` | 2390 | `Cwm` prefix in CWM components, `Eb` in EventBooking | a `<Vendor>` prefix on every Model/View/Table class |
| `skills/joomla/references/module.md` | 278 | `Proclaim example`: The Proclaim project has modules under `modules/admin/` and `modules/site/` | larger Joomla projects often ship modules under both `modules/admin/` and `modules/site/` |

## Kept

`Joomla-Bible-Study/claude-skill-joomla` in `SKILL.md:38` — that's the canonical home of this skill repo, not borrowed code. The "open an issue here" pointer is appropriate.

## Test plan

- [x] `bash scripts/validate.sh` passes.
- [x] `grep -rni "cwm\|proclaim\|biblestudy\|eventbooking" skills/` returns only the canonical repo URL.
- [ ] CI `validate.yml` workflow green.

## Note on PR ordering

This is a small, surgical cleanup off `develop` rather than tacked onto PR #9 (issue #2 component.md audit). PR #9 doesn't touch `SKILL.md` or `module.md`, so the scope here is genuinely independent. Either order of merging works (no conflicts expected — `SKILL.md` and `module.md` aren't touched by #9).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtYsmm8SUPFfDrAVD5qH8)_