### PR TITLE
Coverage-gap triage (#6): plugin-group inventory + scope statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,21 @@ All notable changes to the Joomla skill are documented here. The format follows 
 
 - The per-issue audits (#1–#5) and the J6.1 sweep tail (#11) did the substantive verification of each example against `joomla-cms` HEAD as they landed; this consolidation pass confirms none of those citations have drifted in the weeks since. If `6.1-dev` is replaced by a `6.1-stable` tag (or rolled into `main` for the J6.2 cycle), the permalinks will need a one-shot update — the next sweep should re-run the same matrix.
 
+### Added (issue #6 — coverage-gap triage)
+- `references/plugin.md` — new **"Other plugin groups (not covered in depth here)"** subsection right after the common-groups table. Joomla 6.1 ships 24 plugin groups; the existing table walks 10 of them in detail, and the remaining 14 (`fields`, `quickicon`, `workflow`, `privacy`, `multifactorauth`, `api-authentication`, `authentication`, `captcha`, `filesystem`, `media-action`, `actionlog`, `sampledata`, `behaviour`, `extension`) now get one-line "what it's for" descriptions and an explicit **out-of-scope-for-v0.x** label so users can see at a glance whether a given plugin type is covered. The `SubscriberInterface` wrapping pattern is identical for all of them; only the events / traits / interfaces differ. Also notes that **CLI / `joomla console` command authoring** is out of scope for v0.x and lives inside components rather than as a plugin group — file an issue if depth is needed.
+
+### Verified (issue #6 — coverage-gap triage)
+- Compared the skill's plugin / extension-type coverage against the `plugins/` tree in `joomla-cms` `6.1-dev` (24 groups inventoried via `gh api repos/joomla/joomla-cms/contents/plugins?ref=6.1-dev`). Triage decisions for each:
+
+  | Bucket | Items | Rationale |
+  |--------|-------|-----------|
+  | **Covered in depth** | content, system, finder, task, webservices, schemaorg, user, installer, editors, editors-xtd | Existing `references/plugin.md` walkthroughs + table |
+  | **Covered elsewhere in skill** | workflow (component-side: `SKILL.md` § Workflow Integration, `WorkflowServiceTrait` etc.), form-field XML types (`form-fields.md`), JoomlaEditor JS API + XTD buttons (`editor-api.md`), J6.1 module versions / `custom_data` (`module.md`) | Already present, no gap |
+  | **Surfaced as out-of-scope** | fields (plugin authoring), quickicon, workflow (plugin-side), privacy, MFA, api-authentication, authentication, captcha, filesystem, media-action, actionlog, sampledata, behaviour, extension | Listed in the new "Other plugin groups" subsection with a one-line description so users can self-route. Each is niche enough that going deep here would inflate the skill without serving the typical extension developer. |
+  | **Out of scope, no surface** | CLI / `joomla console` command authoring (not a plugin group; lives inside components) | Mentioned as out-of-scope in the new subsection so users know the skill doesn't cover it; issue can be filed if it's wanted. |
+
+- This triage pass is **descriptive, not prescriptive**: the skill's stated scope ("components, modules, plugins, libraries, templates" focused on common patterns) is preserved. No content was added or removed beyond the new "Other plugin groups" subsection that sets expectations explicitly.
+
 ## [0.1.0] — 2026-04-29
 
 ### Added

--- a/skills/joomla/references/plugin.md
+++ b/skills/joomla/references/plugin.md
@@ -279,6 +279,29 @@ final class Example extends CMSPlugin implements SubscriberInterface
 | **editors** | WYSIWYG editors | `onInit`, `onSave`, `onGetContent` |
 | **editors-xtd** | Editor buttons | `onDisplay` |
 
+### Other plugin groups (not covered in depth here)
+
+Joomla 6.1 ships 24 plugin groups in total. Beyond the ten above, the rest serve narrower needs and aren't walked through in this skill — file an issue if you need depth on one. The wrapping pattern (`SubscriberInterface` + `getSubscribedEvents()` + handler methods) is identical; only the events and the trait/interface layer differ.
+
+| Group | What it's for |
+|-------|---------------|
+| **fields** | Authoring **new custom-field types** that show up in components' field-XML pickers (this is the plugin side; the field-XML *consumption* side is in [`form-fields.md`](form-fields.md)) |
+| **quickicon** | Admin dashboard icons + status checks (`onGetIcons`) |
+| **workflow** | Content-state transition handlers (`onWorkflowBeforeTransition`, `onWorkflowAfterTransition`) — **component-side** workflow integration is documented in `SKILL.md` |
+| **privacy** | GDPR consent + data export/erase requests |
+| **multifactorauth** | MFA methods (replaces J4 `twofactorauth`) |
+| **api-authentication** | Auth providers for the J4+ Web Services API (Bearer tokens, etc.) |
+| **authentication** | Login auth providers (LDAP, OAuth, SSO) |
+| **captcha** | Captcha providers (reCAPTCHA, hCaptcha, etc.) |
+| **filesystem** | Filesystem adapters for the Media Manager (S3, custom remote stores) |
+| **media-action** | Per-image actions inside the Media Manager (crop, resize, etc.) |
+| **actionlog** | Custom entries in the User Actions Log |
+| **sampledata** | Sample-data installers for distribution work |
+| **behaviour** | Mostly home of the **J6 backward-compatibility plugin**; third-party use is rare |
+| **extension** | Generic extension lifecycle hooks (rarely needed when `installer` group covers most cases) |
+
+These are out of scope for the v0.x line because they're either niche or framework-internal. CLI / `joomla console` command authoring (commands ship inside components, not as a plugin group) is also out of scope here — file an issue if you want it added.
+
 ---
 
 ## Event Examples


### PR DESCRIPTION
Sub-task 4 of issue #6 (meta consolidation) — coverage-gap triage. **The last remaining sub-task; closing #6 once this lands.**

## What this PR does

A scope-setting pass, not a content expansion. Inventories the skill's plugin / extension-type coverage against `joomla-cms` 6.1-dev's full plugin catalog, makes triage decisions for each gap, and surfaces the result in the skill so users can self-route.

## Triage matrix

| Bucket | Items | Rationale |
|---|---|---|
| **Covered in depth** | content, system, finder, task, webservices, schemaorg, user, installer, editors, editors-xtd (10 of 24 plugin groups) | Walkthrough table + per-event examples in `references/plugin.md` |
| **Covered elsewhere** | Workflow (component-side: `SKILL.md` § Workflow Integration), form-field XML types (`form-fields.md`), JoomlaEditor JS API + XTD buttons (`editor-api.md`), J6.1 module versions / `custom_data` (`module.md`) | Already present in the skill, no gap |
| **Surfaced as out-of-scope** (this PR) | fields (plugin authoring), quickicon, workflow (plugin-side), privacy, MFA, api-authentication, authentication, captcha, filesystem, media-action, actionlog, sampledata, behaviour, extension (14 of 24 plugin groups) | Listed in a new subsection with one-line descriptions so users see at a glance what's in/out of scope. Each is niche enough that going deep would inflate the skill without serving the typical extension developer. |
| **Out of scope, no surface** | CLI / `joomla console` command authoring (not a plugin group; lives inside components) | Mentioned alongside the out-of-scope subsection so users know the skill doesn't address it; can be filed as an issue if requested. |

## Diff

`references/plugin.md` — 23 lines added: a new **"Other plugin groups (not covered in depth here)"** subsection right after the existing common-groups table. Each of the 14 uncovered groups gets a one-line entry. The wrapping pattern (`SubscriberInterface` + `getSubscribedEvents()` + handler methods) is the same for all of them — what differs is events / traits / interfaces.

`CHANGELOG.md` — adds the Added + Verified entries documenting the inventory and decisions.

## Why no content expansion

The skill's stated scope is "components, modules, plugins, libraries, templates" focused on **common patterns**, not exhaustive plugin-group coverage. Going deep on `multifactorauth` or `media-action` or `actionlog` would multiply the skill's size without serving the typical user. The triage's job is to make that scope explicit, not to violate it.

If a user has a real need for depth on one of the surfaced groups, they can now file a targeted issue ("add a section on quickicon plugins") rather than wonder whether the skill *should* cover it.

## Test plan

- [x] `bash scripts/validate.sh` passes
- [x] Inventoried 24 plugin groups against `gh api repos/joomla/joomla-cms/contents/plugins?ref=6.1-dev` (output recorded inline during the audit)
- [x] Spot-checked uncovered topics (CLI / console, custom field plugin authoring, privacy / MFA / WebAuthn, workflow plugin side) confirm none are mentioned in `SKILL.md` / `references/*.md` today

## Issue #6 status after this PR

- [x] Cross-extension consistency (PR #17, merged)
- [x] Trigger-phrase audit (PR #18, merged)
- [x] Deprecation sweep (PR #19, merged)
- [x] joomla-cms HEAD diff (PR #20, merged)
- [x] **Coverage gaps** (this PR) — closes the last open sub-task

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)