### PR TITLE
Add joomla/Manual repo to Canonical sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Joomla skill are documented here. The format follows 
 ## [Unreleased]
 
 ### Added
+- `SKILL.md` § Canonical sources — added [`github.com/joomla/Manual`](https://github.com/joomla/Manual) (the Markdown source repo backing `manual.joomla.org`) as a sub-bullet under the rendered-manual entry. Useful when you need to grep, fetch raw Markdown, or cite a permalink to a specific manual page; manual corrections also go here as PRs. README cross-reference updated to mention the source repo alongside `manual.joomla.org`.
 - `## Canonical sources` section in `SKILL.md` listing the upstream references the skill is built from (joomla-cms repo, manual.joomla.org, api.joomla.org, framework.joomla.org, docs.joomla.org wiki) with WebFetch-first / fallback guidance and a preference for commit-pinned permalinks. Mirrored in `CONTRIBUTING.md` and `README.md`.
 - `CONTRIBUTING.md` covering testing flow, authoring guidelines, PR process, issue guidelines, and versioning.
 - `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, summarized + linked).

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This skill is maintained by [Christian Web Ministries](https://christianwebminis
 - [CWMScriptureLinks](https://github.com/bcordis/CWMScriptureLinks) — auto-link Scripture references
 - Other CWM extensions
 
-Patterns are derived from the [joomla-cms](https://github.com/joomla/joomla-cms) core and real-world production components. The skill's `## Canonical sources` section in [`skills/joomla/SKILL.md`](skills/joomla/SKILL.md) lists every upstream reference (joomla-cms, manual.joomla.org, api.joomla.org, framework.joomla.org) Claude consults when verifying patterns — and the fallback order when WebFetch is unavailable.
+Patterns are derived from the [joomla-cms](https://github.com/joomla/joomla-cms) core and real-world production components. The skill's `## Canonical sources` section in [`skills/joomla/SKILL.md`](skills/joomla/SKILL.md) lists every upstream reference (joomla-cms, manual.joomla.org + its [`joomla/Manual`](https://github.com/joomla/Manual) source repo, api.joomla.org, framework.joomla.org) Claude consults when verifying patterns — and the fallback order when WebFetch is unavailable.
 
 ## Contributing
 

--- a/skills/joomla/SKILL.md
+++ b/skills/joomla/SKILL.md
@@ -35,6 +35,7 @@ When a Joomla pattern is non-obvious, ambiguous, or might have drifted between v
 **Documentation:**
 
 - [manual.joomla.org](https://manual.joomla.org/) — current Developer Manual (Joomla 5+). Preferred prose reference.
+  - Source repo: [`github.com/joomla/Manual`](https://github.com/joomla/Manual) (default branch `main`) — the Markdown backing the rendered site. Useful when you need to grep, fetch raw, or cite a permalink to a specific page; manual edits / corrections also go here as PRs.
 - [api.joomla.org](https://api.joomla.org/) — generated API reference (classes, methods, signatures).
 - [framework.joomla.org](https://framework.joomla.org/) — Joomla Framework package docs.
 - [docs.joomla.org](https://docs.joomla.org/) — **legacy wiki**. Useful for historical context (J3/J4) but often stale for J5/J6; cross-check against `joomla-cms` HEAD before quoting.


### PR DESCRIPTION
## Summary

- Add [`github.com/joomla/Manual`](https://github.com/joomla/Manual) — the Markdown source repo backing `manual.joomla.org` — to `SKILL.md` § Canonical sources. Paired as a sub-bullet under the existing `manual.joomla.org` entry so the rendered-site / source-repo relationship is explicit.
- Useful because it lets Claude grep / WebFetch the raw Markdown rather than the rendered HTML, and it's where documentation corrections land as PRs.
- Updated `README.md` to mention the source repo alongside `manual.joomla.org`.

## Verification

- `gh api repos/joomla/Manual` → confirms the repo: name `joomla/Manual`, default branch `main`, ~18 MB, description "Joomla Developer Documentation"
- `bash scripts/validate.sh` passes

## Test plan

- [x] Validation passes
- [ ] Try `WebFetch` on a page from the Manual repo's `main` branch (e.g., a raw `.md` file) to confirm the source-repo path produces useful results

🤖 Generated with [Claude Code](https://claude.com/claude-code)