### PR TITLE
Release v0.2.0: stamp version + bump marketplace ref

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,10 @@
       "source": {
         "source": "github",
         "repo": "Joomla-Bible-Study/claude-skill-joomla",
-        "ref": "v0.1.0"
+        "ref": "v0.2.0"
       },
       "description": "Joomla 5+ / 6 extension development skill — components, modules, plugins, templates with modern MVC, PSR-4 namespaces, DI, and service providers.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "category": "development",
       "tags": ["joomla", "php", "cms"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "joomla",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Joomla 5+ / 6 extension development skill — components, modules, plugins, templates with modern MVC, PSR-4 namespaces, DI, and service providers.",
   "author": {
     "name": "Brent Cordis",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to the Joomla skill are documented here. The format follows 
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-04-30
+
+Content audit + Joomla 6.1 alignment release. No breaking changes; tokenized footprint is smaller (`SKILL.md` shrunk by ~1180 lines as Editor API / Form Fields / Testing / Common Gotchas + 5 cross-cutting refs moved to on-demand `references/*.md`). All examples re-verified against `joomla-cms` `6.1-dev` HEAD on 2026-04-30; zero drift across 14 cited permalinks. Closes audit milestone tracked through issues #1–#5, #6, and #11 across 14 merged PRs (#8–#22).
+
+The detailed entry-by-entry list for this release follows below (originally drafted under `[Unreleased]` while the audit campaign was in progress).
+
 ### Added
 - `SKILL.md` § Canonical sources — added [`github.com/joomla/Manual`](https://github.com/joomla/Manual) (the Markdown source repo backing `manual.joomla.org`) as a sub-bullet under the rendered-manual entry. Useful when you need to grep, fetch raw Markdown, or cite a permalink to a specific manual page; manual corrections also go here as PRs. README cross-reference updated to mention the source repo alongside `manual.joomla.org`.
 - `## Canonical sources` section in `SKILL.md` listing the upstream references the skill is built from (joomla-cms repo, manual.joomla.org, api.joomla.org, framework.joomla.org, docs.joomla.org wiki) with WebFetch-first / fallback guidance and a preference for commit-pinned permalinks. Mirrored in `CONTRIBUTING.md` and `README.md`.


### PR DESCRIPTION
Mechanical release stamp following the merge of #23 (v0.2.0 content audit + J6.1 alignment).

## Changes

- **`.claude-plugin/plugin.json`** — `version`: `0.1.0` → `0.2.0`
- **`.claude-plugin/marketplace.json`** — `version`: `0.1.0` → `0.2.0`; `ref`: `v0.1.0` → `v0.2.0` (so `/plugin update` delivers the new release once `v0.2.0` is tagged)
- **`CHANGELOG.md`** — rename `[Unreleased]` heading to `[0.2.0] — 2026-04-30` with a release-overview paragraph; the entry-by-entry list under this section was drafted incrementally during the audit campaign and is preserved verbatim

## After merge

1. Tag `v0.2.0` on the merge commit
2. Push the tag — release workflow auto-publishes the GitHub release
3. Sync `develop` with the new `main` (fast-forward)

## Test plan

- [x] `bash scripts/validate.sh` passes (marketplace.json source still parses, ref form intact)
- [ ] After tag push: confirm release workflow runs and publishes a GitHub release for `v0.2.0`
- [ ] After release: confirm `/plugin update` delivers v0.2.0 to existing installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)