### PR TITLE
Bump workflow actions to Node 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve tag
         id: tag
@@ -58,7 +58,7 @@ jobs:
           echo "file=${out}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.name }}
           name: ${{ steps.tag.outputs.name }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run validation script
         run: bash scripts/validate.sh


### PR DESCRIPTION
## Summary

Resolves the deprecation annotation surfaced on the `v0.4.0` release run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `softprops/action-gh-release@v2`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Changes

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `softprops/action-gh-release` | `@v2` | `@v3` |

Both bumps are pure runtime upgrades to Node 24 per upstream release notes — no input/output schema changes, so the existing `release.yml` and `validate.yml` steps work unchanged.

## Test plan

- [x] Workflow files still parse (diff is 3 lines)
- [ ] CI `validate` check passes on this PR (it'll exercise `actions/checkout@v6`)
- [ ] Next tagged release publishes cleanly without the Node 20 deprecation annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)