### PR TITLE
fix(validate): check the two version files agree

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -91,6 +91,43 @@ else
   fi
 fi
 
+# ---------- version consistency ----------
+# The plugin version lives in two files and a release has to bump both. Each is
+# validated above in isolation, so a release that bumps one and forgets the other
+# passed validation cleanly — which is exactly what happened preparing v1.1.0.
+# Compared here rather than in either section, since neither owns the pair.
+if [ -f "$PLUGIN" ] && [ -f "$MARKET" ] \
+   && jq -e . "$PLUGIN" >/dev/null 2>&1 && jq -e . "$MARKET" >/dev/null 2>&1; then
+  PLUGIN_NAME=$(jq -r '.name // empty' "$PLUGIN")
+  PV=$(jq -r '.version // empty' "$PLUGIN")
+
+  # Match the marketplace entry by name so this keeps working if more plugins
+  # are added; fall back to the sole entry when there is exactly one.
+  MV=$(jq -r --arg n "$PLUGIN_NAME" '
+    (.plugins[] | select(.name == $n) | .version)
+    // (if (.plugins | length) == 1 then .plugins[0].version else empty end)
+    // empty' "$MARKET")
+
+  if [ -z "$PV" ] || [ -z "$MV" ]; then
+    note "could not compare versions (plugin.json='$PV' marketplace.json='$MV') — check manually"
+  elif [ "$PV" != "$MV" ]; then
+    err "version mismatch: plugin.json='$PV' but marketplace.json='$MV' — a release must bump both"
+  else
+    ok "plugin version consistent ($PV)"
+
+    # A version with no changelog entry is a release nobody can read. Warn rather
+    # than fail: the heading is normally added in the same commit, but a
+    # work-in-progress bump is a legitimate intermediate state.
+    if [ -f CHANGELOG.md ]; then
+      if grep -qE "^## \[$PV\]" CHANGELOG.md; then
+        ok "CHANGELOG.md documents $PV"
+      else
+        note "CHANGELOG.md has no '## [$PV]' heading yet — add one before releasing"
+      fi
+    fi
+  fi
+fi
+
 # ---------- README references the install commands ----------
 if [ -f README.md ]; then
   grep -q 'plugin marketplace add Joomla-Bible-Study/claude-skill-joomla' README.md \


### PR DESCRIPTION
Closes #43.

## The gap

The plugin version lives in **two** files:

- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

Each was validated in isolation — parses as JSON, has a `version` key — but nothing compared them. So a release that bumps one and forgets the other passed cleanly.

That is not hypothetical. Preparing **v1.1.0** (#42) I bumped `marketplace.json` to `1.1.0` and left `plugin.json` at `1.0.2`, and `validate.sh` reported:

```
  ok  .claude-plugin/plugin.json parses as JSON
  ok  .claude-plugin/marketplace.json parses as JSON

Validation passed.
```

Caught by hand. Nothing in the tooling would have.

## The check

Its own section, since neither file owns the pair. The marketplace entry is matched **by plugin name** so this keeps working if more plugins are added, falls back to the sole entry when there is exactly one, and degrades to a `note` rather than an `err` if neither can be resolved — a validator that can't compare shouldn't block a release over it.

Also warns when the current version has no matching `## [x.y.z]` heading in `CHANGELOG.md`. A version nobody can read about is a release problem, but this **warns rather than fails**: bumping the version before writing the entry is a legitimate intermediate state, and the release convention adds both in the same commit anyway.

## Verified both ways

Reproducing the v1.1.0 mistake:

```
::error::version mismatch: plugin.json='1.0.2' but marketplace.json='1.1.0' — a release must bump both
Validation FAILED
```

exit **1**.

Version bumped to 1.2.0 with no changelog entry:

```
  ok  plugin version consistent (1.2.0)
  --  CHANGELOG.md has no '## [1.2.0]' heading yet — add one before releasing
Validation passed.
```

exit **0** — warned, not blocked.

Current repo state passes clean:

```
  ok  plugin version consistent (1.1.0)
  ok  CHANGELOG.md documents 1.1.0
```

## Note

No version bump or changelog entry in this PR — it changes tooling, not the skill content that this project versions. Worth folding into whatever the next content release is rather than cutting a release for a validator change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)